### PR TITLE
Use boto3 config mechanism if AWS keys are not in the ini

### DIFF
--- a/ckanext/datagovsg_s3_resources/upload.py
+++ b/ckanext/datagovsg_s3_resources/upload.py
@@ -34,7 +34,9 @@ def setup_s3_bucket():
     aws_access_key_id = config.get('ckan.datagovsg_s3_resources.s3_aws_access_key_id')
     aws_secret_access_key = config.get('ckan.datagovsg_s3_resources.s3_aws_secret_access_key')
     aws_region_name = config.get('ckan.datagovsg_s3_resources.s3_aws_region_name')
-    if aws_region_name:
+    if not aws_access_key_id or not aws_secret_access_key:
+        s3 = boto3.resource('s3')
+    elif aws_region_name:
         s3 = boto3.resource('s3',
                             aws_access_key_id=aws_access_key_id,
                             aws_secret_access_key=aws_secret_access_key,


### PR DESCRIPTION
Boto3 will look in several locations when searching for credentials. The mechanism in which Boto3 looks for credentials is to search through a list of possible locations and stop as soon as it finds credentials. In the current implementation, this mechanism is not used as the keys are set in the code. With this change, if the creentials are not in the ini file then the code will use boto3 credential search.

The order in which Boto3 searches for credentials is detailed on https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html

